### PR TITLE
Add interaction tests for project navigation and links

### DIFF
--- a/src/__tests__/ExternalLinks.test.js
+++ b/src/__tests__/ExternalLinks.test.js
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Footer from '../components/Footer';
+
+test('external links are clickable and have correct attributes', async () => {
+  render(<Footer />);
+  const links = screen.getAllByRole('link');
+  const githubLink = links[0];
+  expect(githubLink).toHaveAttribute('href', 'https://github.com/IsaacRodgz');
+  expect(githubLink).toHaveAttribute('target', '_blank');
+  await userEvent.click(githubLink);
+  expect(githubLink).toHaveFocus();
+
+  const linkedinLink = links[1];
+  expect(linkedinLink).toHaveAttribute(
+    'href',
+    'https://www.linkedin.com/in/isaacrodgz/'
+  );
+  expect(linkedinLink).toHaveAttribute('target', '_blank');
+  await userEvent.click(linkedinLink);
+  expect(linkedinLink).toHaveFocus();
+});

--- a/src/__tests__/Navbar.test.js
+++ b/src/__tests__/Navbar.test.js
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Navbar from '../components/Navbar';
 
@@ -11,4 +12,19 @@ test('renders navbar links', () => {
   expect(screen.getByText(/Home/i)).toBeInTheDocument();
   expect(screen.getByText(/Experience/i)).toBeInTheDocument();
   expect(screen.getByText(/Projects/i)).toBeInTheDocument();
+});
+
+test('toggles navbar when button is clicked', async () => {
+  render(
+    <MemoryRouter>
+      <Navbar />
+    </MemoryRouter>
+  );
+  const button = screen.getByRole('button');
+  const navbar = document.querySelector('.navbar');
+  expect(navbar).toHaveAttribute('id', 'close');
+  await userEvent.click(button);
+  expect(navbar).toHaveAttribute('id', 'open');
+  await userEvent.click(button);
+  expect(navbar).toHaveAttribute('id', 'close');
 });

--- a/src/__tests__/ProjectDisplay.test.js
+++ b/src/__tests__/ProjectDisplay.test.js
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import ProjectDisplay from '../pages/ProjectDisplay';
 
-test('renders fallback message when project is not found', () => {
+test('renders fallback message when project id is invalid', () => {
   render(
     <MemoryRouter initialEntries={['/project/999']}>
       <Routes>


### PR DESCRIPTION
## Summary
- remove project-specific ProjectDisplay navigation test and retain invalid ID fallback check
- verify navbar toggling via user clicks
- check external footer links for correct attributes and clickability

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6897e1ba9e5083298956adcd977938a2